### PR TITLE
tolerate MAIL parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/murphysean/smtp
+
+go 1.20


### PR DESCRIPTION
This replaces some of the parsing of the MAIL line with regex. This is considerably more tolerant.

Here is an example of a conversation before and after this change:
```txt
220 localhost ESMTP
EHLO localhost
250-Greets localhost
250-PIPELINING
250-SMTPUTF8
250 8BITMIME
MAIL FROM:<bounces+SRS=Nsvoo=YB@arkdhs.onmicrosoft.com> SIZE=38677 AUTH=<>
501 MAIL command contained invalid address
```
```txt
220 localhost ESMTP
EHLO localhost
250-Greets localhost
250-PIPELINING
250-SMTPUTF8
250 8BITMIME
MAIL FROM:<bounces+SRS=Nsvoo=YB@arkdhs.onmicrosoft.com> SIZE=38677 AUTH=<>
250 Ok
RCPT TO:<bob@example.com>
250 Ok
DATA
354 End data with <CR><LF>.<CR><LF>

MIME-Version: 1.0
From: john@example.com
To: bob@example.com
Date: 19 Apr 2023 13:05:39 -0500
Subject: Test
Content-Type: text/plain; charset=us-ascii
Content-Transfer-Encoding: quoted-printable

this is a test

.
250 OK
QUIT
221 OK
```